### PR TITLE
Stop trying to put null strings in the UUID cache

### DIFF
--- a/src/main/java/net/canarymod/ToolBox.java
+++ b/src/main/java/net/canarymod/ToolBox.java
@@ -496,15 +496,19 @@ public class ToolBox {
         catch (Exception ex) {
             Canary.log.warn("Failed to translate Username into a UUID");
         }
-        if (uuid != null && !uuid.contains("-")) {
-            // Add the hyphens back in
-            uuid = uuid.substring(0, 8) + "-" + uuid.substring(8, 12) + "-" + uuid.substring(12, 16) + "-" + uuid.substring(16, 20) + "-" + uuid.substring(20, 32);
+        if (uuid != null) {
+            if (!uuid.contains("-")) {
+                // Add the hyphens back in
+                uuid = uuid.substring(0, 8) + "-" + uuid.substring(8, 12) + "-" + uuid.substring(12, 16) + "-" + uuid.substring(16, 20) + "-" + uuid.substring(20, 32);
+            }
+
+            // Update the userLookup
+            userLookup.setString(uuid, username);
+            userLookup.setComments(uuid, ";Verified: " + System.currentTimeMillis());
+            userLookup.save();
         }
 
-        // Update the userLookup
-        userLookup.setString(uuid, username);
-        userLookup.setComments(uuid, ";Verified: " + System.currentTimeMillis());
-        userLookup.save();
+        // Return either the UUID string or null if none could be found
         return uuid;
     }
 


### PR DESCRIPTION
Before, the server would try to place the UUID string into the userLookup database even if the String was null, causing a NullPointerException.  This fix verifies that there is an actual UUID to be stored before attempting to put it in the database, and, if there is no UUID to be found, returns null instead of causing an Exception
