### PR TITLE
Fix MessageRaw's permission

### DIFF
--- a/src/main/java/net/canarymod/commandsys/CanaryCommandPermissions.java
+++ b/src/main/java/net/canarymod/commandsys/CanaryCommandPermissions.java
@@ -91,7 +91,7 @@ public enum CanaryCommandPermissions {
             GIVE = "canary.command.give",
             GIVE$OTHER = "canary.command.give.other",
             MESSAGE = "canary.command.message",
-            MESSAGERAW = "canary.command.message",
+            MESSAGERAW = "canary.command.message.raw",
             PLAYSOUND = "canary.command.playsound",
             PLAYSOUND$OTHER = "canary.command.playsound.other",
             SAVE$ALL = "canary.command.save.all",


### PR DESCRIPTION
Permission was "canary.command.message", which gave anyone who wanted to /msg someone the ability to /tellraw as well, which for many servers could be problematic
