### PR TITLE
fixes issue #44

### DIFF
--- a/src/main/java/net/canarymod/api/inventory/recipes/CraftingRecipe.java
+++ b/src/main/java/net/canarymod/api/inventory/recipes/CraftingRecipe.java
@@ -41,6 +41,29 @@ public final class CraftingRecipe {
     }
 
     /**
+     * Constructs a new SHAPED CraftingRecipe. Provided for use by non-Java languages.
+     * 
+     * @param result
+     *         the {@link Item} result of the recipe
+     * @param rows
+     *         the {@link RecipeRow}s that make up the recipe
+     */
+    public static CraftingRecipe createShapedRecipe(Item result, RecipeRow... rows){
+	return new CraftingRecipe(result, rows);
+    }
+
+    /**
+     * Constructs a new SHAPELESS CraftingRecipe. Provided for use by non-Java languages.
+     *
+     * @param result
+     *         the {@link Item} result of the recipe
+     * @param items
+     *         the {@link Item}s that are needed to make the result
+     */
+    public static CraftingRecipe createShapelessRecipe(Item result, Item... items){
+	return new CraftingRecipe(result, items);
+    }
+    /**
      * Checks if this recipe has a shape
      *
      * @return {@code true} if shaped; {@code false} if not


### PR DESCRIPTION
The two constructors for creating shaped and shapeless recipes each have 2 params one of which is an Item and the other a Var-Arg of type Item or RecipeRow. 
Unfortunately Nashorn (the js engine bundled with Java) cannot differentiate between them even when using signature narrowing. 
Need to add createShapelessRecipe() and createShapedRecipe() static methods. I'm opening this issue pending a pull request.
