### PR TITLE
Sort bans by BanType

### DIFF
--- a/src/main/java/net/canarymod/bansystem/Ban.java
+++ b/src/main/java/net/canarymod/bansystem/Ban.java
@@ -12,7 +12,7 @@ import net.canarymod.backbone.BackboneBans;
  */
 public class Ban {
     private String uuid, subject, reason, moderator, ip = "xxx.xxx.xxx.xxx";
-    private boolean isIpBan = false;
+    private BanType banType = BanType.UUID;
     private long issued = ToolBox.getUnixTimestamp(), expiration = -1;
 
     /**
@@ -30,14 +30,22 @@ public class Ban {
     }
 
     public Ban(PlayerReference player, String reason, long expiration, boolean ipBan) {
+        this(player, reason, expiration, ipBan ? BanType.IP : BanType.UUID);
+    }
+
+    public Ban(PlayerReference player, String reason, BanType banType) {
+        this(player, reason, -1, banType);
+    }
+
+    public Ban(PlayerReference player, String reason, long expiration, BanType banType) {
         this.uuid = player.getUUIDString();
         this.subject = player.getName();
         this.reason = reason;
         this.expiration = expiration;
 
-        if (ipBan) {
+        if(banType == BanType.IP) {
             this.ip = player.getIP();
-            this.isIpBan = true;
+            this.banType = BanType.IP;
         }
     }
 
@@ -158,7 +166,7 @@ public class Ban {
      * @return {@code true} if IP Ban; {@code false} if not
      */
     public boolean isIpBan() {
-        return isIpBan;
+        return banType == BanType.IP;
     }
 
     /**
@@ -168,7 +176,25 @@ public class Ban {
      *         {@code true} for IP Ban; {@code false} for not
      */
     public void setIsIpBan(boolean isIpBan) {
-        this.isIpBan = isIpBan;
+        this.banType = isIpBan ? BanType.IP : BanType.UUID;
+    }
+
+    /**
+     * Checks the ban type
+     *
+     * @return the correct ban type for this ban
+     */
+    public BanType getBanType() {
+        return banType;
+    }
+
+    /**
+     * Sets the ban type
+     *
+     * @param banType the ban type to apply to this ban
+     */
+    public void setBanType(BanType banType) {
+        this.banType = banType;
     }
 
     /**

--- a/src/main/java/net/canarymod/bansystem/BanManager.java
+++ b/src/main/java/net/canarymod/bansystem/BanManager.java
@@ -204,7 +204,7 @@ public class BanManager {
     /**
      * Gets a {@link Ban} for a given player's uuid
      *
-     * @param player
+     * @param uuid
      *         the uuid of the player
      *
      * @return the Ban if exists; {@code null} otherwise
@@ -282,6 +282,26 @@ public class BanManager {
         Ban[] retT = {};
 
         return bans.toArray(retT);
+    }
+
+    /**
+     * Get all bans of a certain BanType
+     *
+     * @param banType The BanType the ban will be sorted by
+     *
+     * @return an Array of {@link Ban}(s)
+     */
+    public Ban[] getAllBans(BanType banType) {
+        List<Ban> typeBans = new ArrayList<Ban>();
+
+        for (Ban b : bans) {
+            if (b.getBanType() == banType) {
+                typeBans.add(b);
+            }
+        }
+
+        Ban[] retT = {};
+        return typeBans.toArray(retT);
     }
 
     /**

--- a/src/main/java/net/canarymod/bansystem/BanType.java
+++ b/src/main/java/net/canarymod/bansystem/BanType.java
@@ -1,0 +1,18 @@
+package net.canarymod.bansystem;
+
+/**
+ * The enum of ban types
+ *
+ * @author Jamie (jamierocks)
+ */
+public enum BanType {
+    /**
+     * A ban applied to a UUID
+     */
+    UUID,
+
+    /**
+     * A ban applied to an IP
+     */
+    IP
+}


### PR DESCRIPTION
This is 100% backward compatible with plugins using the boolean version.

This now allows developers to sort and fetch bans, by type.