### PR TITLE
Overhaul attributes API

### DIFF
--- a/src/main/java/net/canarymod/api/attributes/AttributeMap.java
+++ b/src/main/java/net/canarymod/api/attributes/AttributeMap.java
@@ -7,21 +7,60 @@ import java.util.Collection;
 
 /**
  * @author Jason (darkdiplomat)
+ * @author Jamie Mansfield (jamierocks)
  */
 @Beta
 public interface AttributeMap {
 
-    ModifiedAttribute getModifiedAttribute(Attribute attribute);
+    ModifiableAttribute getAttribute(Attribute attribute);
 
-    ModifiedAttribute getModifiedAttributeByName(String name);
+    ModifiableAttribute getAttributeByName(String name);
 
-    ModifiedAttribute registerAttribute(Attribute attribute);
+    ModifiableAttribute register(Attribute attribute);
 
-    Collection<ModifiedAttribute> getAllAttributes();
+    /**
+     * Gets an immutable view of all the registered {@link ModifiableAttribute}s.
+     *
+     * @return An immutable view of registered attributes
+     */
+    Collection<ModifiableAttribute> getAttributes();
 
-    void addModifier(ModifiedAttribute attribute);
+    void addModifier(ModifiableAttribute attribute);
 
     void removeModifiers(Multimap<String, AttributeModifier> map);
 
     void applyModifiers(Multimap<String, AttributeModifier> map);
+
+    /**
+     * @deprecated Replaced by {@link #getAttribute(Attribute)}
+     */
+    @Deprecated
+    ModifiedAttribute getModifiedAttribute(Attribute attribute);
+
+    /**
+     * @deprecated Replaced by {@link #getAttributeByName(String)}
+     */
+    @Deprecated
+    ModifiedAttribute getModifiedAttributeByName(String name);
+
+    /**
+     * @deprecated Replaced by {@link #register(Attribute)}
+     */
+    @Deprecated
+    ModifiedAttribute registerAttribute(Attribute attribute);
+
+    /**
+     * Gets an immutable view of all the registered {@link ModifiedAttribute}s.
+     *
+     * @return An immutable view of registered attributes
+     * @deprecated Replaced by {@link #getAttributes()}
+     */
+    @Deprecated
+    Collection<ModifiedAttribute> getAllAttributes();
+
+    /**
+     * @deprecated Replaced by {@link #addModifier(ModifiableAttribute)}
+     */
+    @Deprecated
+    void addModifier(ModifiedAttribute attribute);
 }

--- a/src/main/java/net/canarymod/api/attributes/AttributeMap.java
+++ b/src/main/java/net/canarymod/api/attributes/AttributeMap.java
@@ -12,10 +12,29 @@ import java.util.Collection;
 @Beta
 public interface AttributeMap {
 
+    /**
+     * Retrieves the modifiable attribute instance from the {@link Attribute}.
+     *
+     * @param attribute The attribute
+     * @return The modifiable attribute instance
+     */
     ModifiableAttribute getAttribute(Attribute attribute);
 
+    /**
+     * Retrieves the modifiable attribute instance from the attribute's name.
+     *
+     * @param name The attribute's name
+     * @return The modifiable attribute instance
+     */
     ModifiableAttribute getAttributeByName(String name);
 
+    /**
+     * Registers the given {@link Attribute} to the attribute map, providing
+     * a modifiable attribute instance.
+     *
+     * @param attribute The attribute to register
+     * @return The modifiable attribute instance
+     */
     ModifiableAttribute register(Attribute attribute);
 
     /**
@@ -25,25 +44,53 @@ public interface AttributeMap {
      */
     Collection<ModifiableAttribute> getAttributes();
 
+    /**
+     * Adds the attribute instance to the map.
+     *
+     * @param attribute The attribute instance
+     */
     void addModifier(ModifiableAttribute attribute);
 
+    /**
+     * Removes the given modifiers, from the attribute instance of the given name.
+     *
+     * @param map A {@link Multimap} of attribute instance name -> modifiers
+     */
     void removeModifiers(Multimap<String, AttributeModifier> map);
 
+    /**
+     * Applies the given modifiers, from the attribute instance of the given name.
+     *
+     * @param map A {@link Multimap} of attribute instance name -> modifiers
+     */
     void applyModifiers(Multimap<String, AttributeModifier> map);
 
     /**
+     * Retrieves the modifiable attribute instance from the {@link Attribute}.
+     *
+     * @param attribute The attribute
+     * @return The modifiable attribute instance
      * @deprecated Replaced by {@link #getAttribute(Attribute)}
      */
     @Deprecated
     ModifiedAttribute getModifiedAttribute(Attribute attribute);
 
     /**
+     * Retrieves the modifiable attribute instance from the attribute's name.
+     *
+     * @param name The attribute's name
+     * @return The modifiable attribute instance
      * @deprecated Replaced by {@link #getAttributeByName(String)}
      */
     @Deprecated
     ModifiedAttribute getModifiedAttributeByName(String name);
 
     /**
+     * Registers the given {@link Attribute} to the attribute map, providing
+     * a modifiable attribute instance.
+     *
+     * @param attribute The attribute to register
+     * @return The modifiable attribute instance
      * @deprecated Replaced by {@link #register(Attribute)}
      */
     @Deprecated
@@ -59,6 +106,9 @@ public interface AttributeMap {
     Collection<ModifiedAttribute> getAllAttributes();
 
     /**
+     * Adds the attribute instance to the map.
+     *
+     * @param attribute The attribute instance
      * @deprecated Replaced by {@link #addModifier(ModifiableAttribute)}
      */
     @Deprecated

--- a/src/main/java/net/canarymod/api/attributes/AttributeModifier.java
+++ b/src/main/java/net/canarymod/api/attributes/AttributeModifier.java
@@ -20,8 +20,19 @@ public interface AttributeModifier {
      */
     UUID getId();
 
+    /**
+     * Gets the name of the modifier.
+     *
+     * @return The name
+     */
     String getName();
 
+    /**
+     * Gets the operation of which the modifier performs, to the {@link Attribute}.
+     *
+     * @return The operation
+     * @see Operations for a list of potential operations
+     */
     int getOperation();
 
     /**

--- a/src/main/java/net/canarymod/api/attributes/AttributeModifier.java
+++ b/src/main/java/net/canarymod/api/attributes/AttributeModifier.java
@@ -5,20 +5,85 @@ import com.google.common.annotations.Beta;
 import java.util.UUID;
 
 /**
+ * A modifier that can alter the value of an {@link Attribute}.
+ *
  * @author Jason (darkdiplomat)
+ * @author Jamie Mansfield (jamierocks)
  */
 @Beta
 public interface AttributeModifier {
 
-    UUID getUUID();
+    /**
+     * Gets the identifier of the modifier.
+     *
+     * @return The identifier
+     */
+    UUID getId();
 
     String getName();
 
     int getOperation();
 
+    /**
+     * Gets the value of the modifier.
+     *
+     * @return The modifier's value
+     */
+    double getValue();
+
+    /**
+     * Gets whether the modifier should be saved to file.
+     *
+     * @return {@code true} if the modifier should be saved to file,
+     *         {@code false} otherwise
+     */
+    boolean getShouldSave();
+
+    /**
+     * Sets whether the modifier should be saved to file.
+     *
+     * @param saved {@code true} if the modifier should be saved to file,
+     *              {@code false} otherwise
+     * @return {@code this} for chaining
+     */
+    AttributeModifier setShouldSave(boolean saved);
+
+    /**
+     * Gets the identifier of the modifier.
+     *
+     * @return The identifier
+     * @deprecated Replaced by {@link #getId()}
+     */
+    @Deprecated
+    UUID getUUID();
+
+    /**
+     * Gets the value of the modifier.
+     *
+     * @return The modifier's value
+     * @deprecated Replaced by {@link #getValue()}
+     */
+    @Deprecated
     double getAmount();
 
+    /**
+     * Gets whether the modifier should be saved to file.
+     *
+     * @return {@code true} if the modifier should be saved to file,
+     *         {@code false} otherwise
+     * @deprecated Replaced by {@link #getShouldSave()}
+     */
+    @Deprecated
     boolean isSaved();
 
+    /**
+     * Sets whether the modifier should be saved to file.
+     *
+     * @param saved {@code true} if the modifier should be saved to file,
+     *              {@code false} otherwise
+     * @return {@code this} for chaining
+     * @deprecated Replaced by {@link #setShouldSave(boolean)}
+     */
+    @Deprecated
     AttributeModifier setSaved(boolean saved);
 }

--- a/src/main/java/net/canarymod/api/attributes/GenericAttribute.java
+++ b/src/main/java/net/canarymod/api/attributes/GenericAttribute.java
@@ -22,7 +22,7 @@ public enum GenericAttribute {
 
     private final String nmsName;
 
-    private GenericAttribute(String nmsName) {
+    GenericAttribute(String nmsName) {
         this.nmsName = nmsName;
     }
 

--- a/src/main/java/net/canarymod/api/attributes/GenericAttribute.java
+++ b/src/main/java/net/canarymod/api/attributes/GenericAttribute.java
@@ -8,16 +8,12 @@ import net.canarymod.Canary;
  */
 @Beta
 public enum GenericAttribute {
+
     MAXHEALTH("generic.maxHealth"),
-    //
     FOLLOWRANGE("generic.followRange"),
-    //
     MOVEMENTSPEED("generic.movementSpeed"),
-    //
     ATTACKDAMAGE("generic.attackDamage"),
-    //
     KNOCKBACKRESIST("generic.knockbackResistance"),
-    //
     ;
 
     private final String nmsName;
@@ -27,11 +23,11 @@ public enum GenericAttribute {
     }
 
     public Attribute getAttribute() {
-        return Canary.factory().getAttributeFactory().getGenericAttribute(nmsName);
+        return Canary.factory().getAttributeFactory().getGenericAttribute(this.nmsName);
     }
 
     public String getNativeName() {
-        return nmsName;
+        return this.nmsName;
     }
 
 }

--- a/src/main/java/net/canarymod/api/attributes/HorseAttribute.java
+++ b/src/main/java/net/canarymod/api/attributes/HorseAttribute.java
@@ -9,7 +9,8 @@ import net.canarymod.Canary;
 @Beta
 public enum HorseAttribute {
 
-    JUMPSTRENGTH("horse.jumpStrength");
+    JUMPSTRENGTH("horse.jumpStrength"),
+    ;
 
     private final String nmsName;
 

--- a/src/main/java/net/canarymod/api/attributes/ModifiableAttribute.java
+++ b/src/main/java/net/canarymod/api/attributes/ModifiableAttribute.java
@@ -1,0 +1,29 @@
+package net.canarymod.api.attributes;
+
+import com.google.common.annotations.Beta;
+
+import java.util.UUID;
+
+/**
+ * An instance of an {@link Attribute} that can be modified.
+ *
+ * @author Jason (darkdiplomat)
+ * @author Jamie Mansfield (jamierocks)
+ */
+@Beta
+public interface ModifiableAttribute {
+
+    Attribute getAttribute();
+
+    double getBaseValue();
+
+    void setBaseValue(double value);
+
+    AttributeModifier getModifier(UUID uuid);
+
+    void apply(AttributeModifier attributeModifier);
+
+    void remove(AttributeModifier attributeModifier);
+
+    double getValue();
+}

--- a/src/main/java/net/canarymod/api/attributes/ModifiedAttribute.java
+++ b/src/main/java/net/canarymod/api/attributes/ModifiedAttribute.java
@@ -1,26 +1,12 @@
 package net.canarymod.api.attributes;
 
-import com.google.common.annotations.Beta;
-
-import java.util.UUID;
-
 /**
+ * An instance of an {@link Attribute} that can be modified.
+ *
  * @author Jason (darkdiplomat)
+ * @author Jamie Mansfield (jamierocks)
+ * @deprecated Replaced by {@link ModifiableAttribute}
  */
-@Beta
-public interface ModifiedAttribute {
-
-    Attribute getAttribute();
-
-    double getBaseValue();
-
-    void setBaseValue(double value);
-
-    AttributeModifier getModifier(UUID uuid);
-
-    void apply(AttributeModifier attributeModifier);
-
-    void remove(AttributeModifier attributeModifier);
-
-    double getValue();
+@Deprecated
+public interface ModifiedAttribute extends ModifiableAttribute {
 }

--- a/src/main/java/net/canarymod/api/attributes/Operations.java
+++ b/src/main/java/net/canarymod/api/attributes/Operations.java
@@ -1,0 +1,17 @@
+package net.canarymod.api.attributes;
+
+/**
+ * A psuedo-enum of operations within Minecraft.
+ *
+ * @author Jamie Mansfield (jamierocks)
+ */
+public final class Operations {
+
+    public static final int ADD_AMOUNT = 0;
+    public static final int MULTIPLY_BASE = 1;
+    public static final int MULTIPLY = 2;
+
+    private Operations() {
+    }
+
+}

--- a/src/main/java/net/canarymod/api/attributes/ZombieAttribute.java
+++ b/src/main/java/net/canarymod/api/attributes/ZombieAttribute.java
@@ -9,7 +9,8 @@ import net.canarymod.Canary;
 @Beta
 public enum ZombieAttribute {
 
-    SPAWNREINFORCEMENTS("zombie.spawnReinforcements");
+    SPAWNREINFORCEMENTS("zombie.spawnReinforcements"),
+    ;
 
     private final String nmsName;
 

--- a/src/main/java/net/canarymod/api/factory/AttributeFactory.java
+++ b/src/main/java/net/canarymod/api/factory/AttributeFactory.java
@@ -2,6 +2,9 @@ package net.canarymod.api.factory;
 
 import com.google.common.annotations.Beta;
 import net.canarymod.api.attributes.Attribute;
+import net.canarymod.api.attributes.AttributeModifier;
+
+import java.util.UUID;
 
 /**
  * @author Jason (darkdiplomat)
@@ -20,4 +23,25 @@ public interface AttributeFactory {
      * @return generic Attribute
      */
     Attribute getGenericAttribute(String nativeName);
+
+    /**
+     * Creates an {@link AttributeModifier} of the given properties.
+     *
+     * @param name The name of the modifier
+     * @param value The value of the modifier
+     * @param operation The operation the modifier performs
+     * @return The created modifier
+     */
+    AttributeModifier createModifier(String name, double value, int operation);
+
+    /**
+     * Creates an {@link AttributeModifier} of the given properties.
+     *
+     * @param id The identifier of the modifier
+     * @param name The name of the modifier
+     * @param value The value of the modifier
+     * @param operation The operation the modifier performs
+     * @return The created modifier
+     */
+    AttributeModifier createModifier(UUID id, String name, double value, int operation);
 }


### PR DESCRIPTION
## Foreword

**note**: *despite the API being largely @Beta marked, this PR is completely backwards-compatible*.

## Changes

- **AttributeModifier** (name unchanged)
  - getUUID() -> **getId()** (named after the property, not the type)
  - getAmount() -> **getValue()** (more representative of what it is)
  - isSaved() -> **getShouldSave()** (it hasn't been saved yet, its to potentially be saved)
  - setSaved(bool) -> **setShouldSave(bool)** (it hasn't been saved yet, its to potentially be saved)
- **ModifiableAttribute** (name changed from ModififiedAttribute - that would be an immutable object)
  - (*the appropriate changes in AttributeMap for the name change - the new methods often renamed*)
- **AttributeFactory** (name unchanged)
  - Add methods for creating modifiers
- **Operations** (introduced as a psuedo-enum of potential operations)

## Potential Changes

- **AttributeModifier**
  - [ ] getShouldSave() vs getShouldSerialize() (serialize being both an appropriate term, and used by MC)
  - [ ] setShouldSave(bool) vs setShouldSerialize(bool) (serialize being both an appropriate term, and used by MC)